### PR TITLE
[Bumpup v0.0.2] Request single service from a single protobuf definition file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,61 @@ npm install -g artillery-engine-grpc
 
 ### Define your scenario
 
+#### .proto file
+
+```proto
+syntax = "proto3";
+
+package backend.services.v1;
+
+service HelloService {
+    rpc Hello (HelloRequest) returns (HelloResponse) {
+    }
+}
+
+message HelloRequest {
+    int32 id = 1;
+    string name = 2;
+}
+
+message HelloResponse {
+    string message = 1;
+}
+```
+
+#### scenario file
+
 ```yml
 # my-scenario.yml
+# @doc https://artillery.io/docs/script-reference/
 config:
-  target: 'https://localhost:8000'
+  target: 127.0.0.1:8080
   phases:
-    - duration: 60
-      arrivalRate: 20
+    - duration: 10 #sec
+      arrivalRate: 10
+      pause: 15 #sec
   engines:
-    grpc: {}
-  defaults:
-    protobufDefinition: ''
+    grpc:
+      protobufDefinition:
+        filepath: protobuf-definitions/backend/services/v1/hello.proto
+        package: backend.services.v1
+        service: HelloService
 
 scenarios:
-  name: 'test gRPC Application'
-  engine: 'grpc'
-  flow:
+  - name: test backend-service running at http://localhost:8000
+    engine: grpc
+    flow:
+    # list RPC names with its arguments
     - Hello:
-        foo: "var"
+        id: 1
+        name: Alice
+    - Hello:
+        id: 2
+        name: Bob
+    - Hello:
+        id: 3
+        name: Chris
+
 ```
 
 ### Run the scenario

--- a/index.js
+++ b/index.js
@@ -29,11 +29,16 @@ function ArtilleryGRPCEngine(script, ee, helpers) {
     return grpc.loadPackageDefinition(packageDefinition)
   }
 
-  function initClient() {
+  function getService() {
     const grpcObject = loadPackageDefinition()
-    // TODO: make it meta programming
-    console.log('#initialized')
-    const client = new grpcObject.backend.services.v1[service](
+    const packages = package.split('.')
+    const services = packages.reduce((obj, p) => obj = obj[p], grpcObject)
+    return services[service]
+  }
+
+  function initClient() {
+    const service = getService()
+    const client = new service(
       target,
       grpc.credentials.createInsecure(),
     )

--- a/index.js
+++ b/index.js
@@ -9,15 +9,15 @@ function ArtilleryGRPCEngine(script, ee, helpers) {
   const { config } = this.script
   const { target, engines } = config
   const {
-    protobufDefinition,
+    filepath,
     service,
     package,
-  } = engines.grpc
+  } = engines.grpc.protobufDefinition
 
   // @return GrpcObject
   function loadPackageDefinition() {
     const packageDefinition = protoLoader.loadSync(
-      protobufDefinition,
+      filepath,
       {
         keepCase: true,
         longs: String,
@@ -33,7 +33,7 @@ function ArtilleryGRPCEngine(script, ee, helpers) {
     const grpcObject = loadPackageDefinition()
     // TODO: make it meta programming
     console.log('#initialized')
-    const client = new grpcObject.backend.services.v1.HelloService(
+    const client = new grpcObject.backend.services.v1[service](
       target,
       grpc.credentials.createInsecure(),
     )

--- a/index.js
+++ b/index.js
@@ -50,28 +50,24 @@ function ArtilleryGRPCEngine(script, ee, helpers) {
 }
 
 ArtilleryGRPCEngine.prototype.createScenario = function createScenario(scenarioSpec, ee) {
-  function executeScenario() {
+  const executeScenario = () => {
     ee.emit('started')
+
+    scenarioSpec.flow.forEach((flow) => {
+      Object.keys(flow).forEach((rpcName) => {
+        const args = flow[rpcName]
+        this.client[rpcName](args, (error, response) => {
+          if (error) {
+            ee.emit('error', error)
+          } else {
+            ee.emit('response', response)
+          }
+        })
+      })
+    })
 
     ee.emit('done')
   }
-
-  console.log('#createScenario')
-  console.log(scenarioSpec)
-
-  scenarioSpec.flow.forEach((flow) => {
-    Object.keys(flow).forEach((rpcName) => {
-      const args = flow[rpcName]
-      this.client[rpcName](args, (error, response) => {
-        if (error) {
-          console.error(error)
-        } else {
-          console.log(response)
-        }
-      })
-    })
-  })
-
   return executeScenario
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artillery-engine-grpc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Load test your gRPC application with Artillery.io",
   "main": "index.js",
   "scripts": {

--- a/sample/load-test.yml
+++ b/sample/load-test.yml
@@ -6,10 +6,17 @@ config:
   engines:
     grpc:
       protobufDefinition: 'protobuf-definitions/backend/services/v1/hello.proto'
+      package: 'backend.services.v1'
+      service: HelloService
 
 scenarios:
   - name: "test backend-service running at http://localhost:8000"
     engine: "grpc"
     flow:
-    - get:
-        url: "/docs"
+    # list RPC names with its arguments
+    - Hello:
+        id: 1
+        name: 'Alice'
+    - Hello:
+        id: 2
+        name: 'Bob'

--- a/sample/load-test.yml
+++ b/sample/load-test.yml
@@ -5,9 +5,10 @@ config:
       arrivalRate: 20
   engines:
     grpc:
-      protobufDefinition: protobuf-definitions/backend/services/v1/hello.proto
-      package: backend.services.v1
-      service: HelloService
+      protobufDefinition:
+        filepath: protobuf-definitions/backend/services/v1/hello.proto
+        package: backend.services.v1
+        service: HelloService
 
 scenarios:
   - name: test backend-service running at http://localhost:8000

--- a/sample/load-test.yml
+++ b/sample/load-test.yml
@@ -1,22 +1,25 @@
 config:
-  target: '127.0.0.1:8080'
+  target: 127.0.0.1:8080
   phases:
     - duration: 60
       arrivalRate: 20
   engines:
     grpc:
-      protobufDefinition: 'protobuf-definitions/backend/services/v1/hello.proto'
-      package: 'backend.services.v1'
+      protobufDefinition: protobuf-definitions/backend/services/v1/hello.proto
+      package: backend.services.v1
       service: HelloService
 
 scenarios:
-  - name: "test backend-service running at http://localhost:8000"
-    engine: "grpc"
+  - name: test backend-service running at http://localhost:8000
+    engine: grpc
     flow:
     # list RPC names with its arguments
     - Hello:
         id: 1
-        name: 'Alice'
+        name: Alice
     - Hello:
         id: 2
-        name: 'Bob'
+        name: Bob
+    - Hello:
+        id: 3
+        name: Chris

--- a/sample/load-test.yml
+++ b/sample/load-test.yml
@@ -1,8 +1,10 @@
+# @doc https://artillery.io/docs/script-reference/
 config:
   target: 127.0.0.1:8080
   phases:
-    - duration: 60
-      arrivalRate: 20
+    - duration: 10 #sec
+      arrivalRate: 10
+      pause: 15 #sec
   engines:
     grpc:
       protobufDefinition:


### PR DESCRIPTION
## Usage

#### .proto file

```proto
syntax = "proto3";

package backend.services.v1;

service HelloService {
    rpc Hello (HelloRequest) returns (HelloResponse) {
    }
}

message HelloRequest {
    int32 id = 1;
    string name = 2;
}

message HelloResponse {
    string message = 1;
}
```

#### scenario file

```yml
# my-scenario.yml
# @doc https://artillery.io/docs/script-reference/
config:
  target: 127.0.0.1:8080
  phases:
    - duration: 10 #sec
      arrivalRate: 10
      pause: 15 #sec
  engines:
    grpc:
      protobufDefinition:
        filepath: protobuf-definitions/backend/services/v1/hello.proto
        package: backend.services.v1
        service: HelloService

scenarios:
  - name: test backend-service running at http://localhost:8000
    engine: grpc
    flow:
    # list RPC names with its arguments
    - Hello:
        id: 1
        name: Alice
    - Hello:
        id: 2
        name: Bob
    - Hello:
        id: 3
        name: Chris
```