### PR TITLE
[Bumpup 0.0.3] Show `engine.grpc.*` metrics

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,11 +59,18 @@ ArtilleryGRPCEngine.prototype.step = function step(ops, ee) {
     };
   }
 
+  const startedAt = process.hrtime();
+
   // gRPC request
   return gRPCRequest = (context, callback) => {
     Object.keys(ops).map((rpcName) => {
       const args = ops[rpcName]
       this.client[rpcName](args, (error, response) => {
+        const endedAt = process.hrtime(startedAt);
+        const delta = (endedAt[0] * 1e9) + endedAt[1]; // NOTE: 1e9 means 1 * 10 to the 9th power, which is 1 billion (1000000000).
+        ee.emit('counter', 'engine.grpc.responses', 1);
+        ee.emit('histogram', 'engine.grpc.response_time', delta / 1e6); // NOTE: 1e6 means 1 * 10 to the 6th power, which is 1 million (1000000).
+
         if (error) {
           ee.emit('error', error)
           return callback(err, context);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
+const A = require('async');
 const grpc = require('grpc')
 const protoLoader = require('@grpc/proto-loader')
+
+const { log: logger } = console
 
 function ArtilleryGRPCEngine(script, ee, helpers) {
   this.script = script
@@ -43,25 +46,56 @@ ArtilleryGRPCEngine.prototype.initGRPCClient = function initClient(config) {
 }
 
 ArtilleryGRPCEngine.prototype.createScenario = function createScenario(scenarioSpec, ee) {
-  const executeScenario = () => {
-    ee.emit('started')
+  const tasks = scenarioSpec.flow.map((ops) => this.step(ops, ee))
 
-    scenarioSpec.flow.forEach((flow) => {
-      Object.keys(flow).forEach((rpcName) => {
-        const args = flow[rpcName]
-        this.client[rpcName](args, (error, response) => {
-          if (error) {
-            ee.emit('error', error)
-          } else {
-            ee.emit('response', response)
-          }
-        })
+  return this.compile(tasks, scenarioSpec.flow, ee)
+}
+
+ArtilleryGRPCEngine.prototype.step = function step(ops, ee) {
+  if (ops.log) {
+    return (context, callback) => {
+      logger(this.helpers.template(ops.log, context))
+      return process.nextTick(() => { callback(null, context); });
+    };
+  }
+
+  // gRPC request
+  return gRPCRequest = (context, callback) => {
+    Object.keys(ops).map((rpcName) => {
+      const args = ops[rpcName]
+      this.client[rpcName](args, (error, response) => {
+        if (error) {
+          ee.emit('error', error)
+          return callback(err, context);
+        } else {
+          ee.emit('response', response)
+          return callback(null, context);
+        }
       })
     })
-
-    ee.emit('done')
   }
-  return executeScenario
+}
+
+ArtilleryGRPCEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
+  return function scenario(initialContext, callback) {
+    const init = function init(next) {
+      ee.emit('started')
+      return next(null, initialContext)
+    }
+
+    const steps = [init].concat(tasks)
+
+    A.waterfall(
+      steps,
+      function done(err, context) {
+        if (err) {
+          debug(err)
+        }
+
+        return callback(err, context)
+      }
+    )
+  }
 }
 
 module.exports = ArtilleryGRPCEngine

--- a/index.js
+++ b/index.js
@@ -7,12 +7,14 @@ function ArtilleryGRPCEngine(script, ee, helpers) {
   this.helpers = helpers
 
   const { config } = this.script
+  this.client = this.initGRPCClient(config)
+
+  return this
+}
+
+ArtilleryGRPCEngine.prototype.initGRPCClient = function initClient(config) {
   const { target, engines } = config
-  const {
-    filepath,
-    service,
-    package,
-  } = engines.grpc.protobufDefinition
+  const { filepath, service, package, } = engines.grpc.protobufDefinition
 
   // @return GrpcObject
   function loadPackageDefinition() {
@@ -29,24 +31,15 @@ function ArtilleryGRPCEngine(script, ee, helpers) {
     return grpc.loadPackageDefinition(packageDefinition)
   }
 
-  function getService() {
+  function getServiceClient() {
     const grpcObject = loadPackageDefinition()
     const packages = package.split('.')
     const services = packages.reduce((obj, p) => obj = obj[p], grpcObject)
     return services[service]
   }
 
-  function initClient() {
-    const service = getService()
-    const client = new service(
-      target,
-      grpc.credentials.createInsecure(),
-    )
-    return client
-  }
-  this.client = initClient()
-
-  return this
+  const serviceClient = getServiceClient()
+  return new serviceClient(target, grpc.credentials.createInsecure())
 }
 
 ArtilleryGRPCEngine.prototype.createScenario = function createScenario(scenarioSpec, ee) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "artillery-engine-grpc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -100,6 +100,11 @@
         "optjs": "~3.2.2"
       }
     },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
     "bytebuffer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
@@ -139,6 +144,14 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
       "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -609,6 +622,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nan": {
       "version": "2.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artillery-engine-grpc",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Load test your gRPC application with Artillery.io",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "homepage": "https://github.com/kenju/artillery-engine-grpc#readme",
   "dependencies": {
     "@grpc/proto-loader": "^0.5.3",
+    "async": "^3.2.0",
+    "debug": "^4.1.1",
     "grpc": "^1.24.2"
   }
 }

--- a/sample/backend-service/backend/services/v1/hello.pb.go
+++ b/sample/backend-service/backend/services/v1/hello.pb.go
@@ -110,15 +110,95 @@ func (m *HelloResponse) GetMessage() string {
 	return ""
 }
 
+type ByeRequest struct {
+	Id                   int32    `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ByeRequest) Reset()         { *m = ByeRequest{} }
+func (m *ByeRequest) String() string { return proto.CompactTextString(m) }
+func (*ByeRequest) ProtoMessage()    {}
+func (*ByeRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_9cb2e5bedbde1b42, []int{2}
+}
+
+func (m *ByeRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ByeRequest.Unmarshal(m, b)
+}
+func (m *ByeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ByeRequest.Marshal(b, m, deterministic)
+}
+func (m *ByeRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ByeRequest.Merge(m, src)
+}
+func (m *ByeRequest) XXX_Size() int {
+	return xxx_messageInfo_ByeRequest.Size(m)
+}
+func (m *ByeRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ByeRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ByeRequest proto.InternalMessageInfo
+
+func (m *ByeRequest) GetId() int32 {
+	if m != nil {
+		return m.Id
+	}
+	return 0
+}
+
+type ByeResponse struct {
+	Message              string   `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ByeResponse) Reset()         { *m = ByeResponse{} }
+func (m *ByeResponse) String() string { return proto.CompactTextString(m) }
+func (*ByeResponse) ProtoMessage()    {}
+func (*ByeResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_9cb2e5bedbde1b42, []int{3}
+}
+
+func (m *ByeResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ByeResponse.Unmarshal(m, b)
+}
+func (m *ByeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ByeResponse.Marshal(b, m, deterministic)
+}
+func (m *ByeResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ByeResponse.Merge(m, src)
+}
+func (m *ByeResponse) XXX_Size() int {
+	return xxx_messageInfo_ByeResponse.Size(m)
+}
+func (m *ByeResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ByeResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ByeResponse proto.InternalMessageInfo
+
+func (m *ByeResponse) GetMessage() string {
+	if m != nil {
+		return m.Message
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*HelloRequest)(nil), "backend.services.v1.HelloRequest")
 	proto.RegisterType((*HelloResponse)(nil), "backend.services.v1.HelloResponse")
+	proto.RegisterType((*ByeRequest)(nil), "backend.services.v1.ByeRequest")
+	proto.RegisterType((*ByeResponse)(nil), "backend.services.v1.ByeResponse")
 }
 
 func init() { proto.RegisterFile("backend/services/v1/hello.proto", fileDescriptor_9cb2e5bedbde1b42) }
 
 var fileDescriptor_9cb2e5bedbde1b42 = []byte{
-	// 178 bytes of a gzipped FileDescriptorProto
+	// 214 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4f, 0x4a, 0x4c, 0xce,
 	0x4e, 0xcd, 0x4b, 0xd1, 0x2f, 0x4e, 0x2d, 0x2a, 0xcb, 0x4c, 0x4e, 0x2d, 0xd6, 0x2f, 0x33, 0xd4,
 	0xcf, 0x48, 0xcd, 0xc9, 0xc9, 0xd7, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x86, 0x2a, 0xd0,
@@ -127,10 +207,12 @@ var fileDescriptor_9cb2e5bedbde1b42 = []byte{
 	0x62, 0xca, 0x4c, 0x11, 0x12, 0xe2, 0x62, 0xc9, 0x4b, 0xcc, 0x4d, 0x95, 0x60, 0x52, 0x60, 0xd4,
 	0xe0, 0x0c, 0x02, 0xb3, 0x95, 0x34, 0xb9, 0x78, 0xa1, 0x7a, 0x8a, 0x0b, 0xf2, 0xf3, 0x8a, 0x53,
 	0x85, 0x24, 0xb8, 0xd8, 0x73, 0x53, 0x8b, 0x8b, 0x13, 0xd3, 0x53, 0xc1, 0x3a, 0x39, 0x83, 0x60,
-	0x5c, 0xa3, 0x04, 0xa8, 0xf1, 0xc1, 0x10, 0x2b, 0x85, 0x02, 0xb8, 0x58, 0xc1, 0x7c, 0x21, 0x45,
-	0x3d, 0x2c, 0xae, 0xd1, 0x43, 0x76, 0x8a, 0x94, 0x12, 0x3e, 0x25, 0x10, 0x9b, 0x95, 0x18, 0x92,
-	0xd8, 0xc0, 0x9e, 0x33, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0x34, 0x06, 0x62, 0x49, 0xff, 0x00,
-	0x00, 0x00,
+	0x5c, 0x25, 0x19, 0x2e, 0x2e, 0xa7, 0xca, 0x54, 0x1c, 0x86, 0x2b, 0xa9, 0x73, 0x71, 0x83, 0x65,
+	0x09, 0x19, 0x63, 0xb4, 0x82, 0x11, 0xea, 0xcc, 0x60, 0x88, 0xd3, 0x85, 0xfc, 0xb8, 0x58, 0xc1,
+	0x7c, 0x21, 0x45, 0x3d, 0x2c, 0xbe, 0xd2, 0x43, 0xf6, 0x92, 0x94, 0x12, 0x3e, 0x25, 0x50, 0xab,
+	0x3d, 0xb8, 0x98, 0x9d, 0x2a, 0x53, 0x85, 0xe4, 0xb1, 0x2a, 0x45, 0xf8, 0x40, 0x4a, 0x01, 0xb7,
+	0x02, 0x88, 0x49, 0x49, 0x6c, 0xe0, 0xc0, 0x36, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0xf3, 0x71,
+	0x95, 0x51, 0x8f, 0x01, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -146,6 +228,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type HelloServiceClient interface {
 	Hello(ctx context.Context, in *HelloRequest, opts ...grpc.CallOption) (*HelloResponse, error)
+	Bye(ctx context.Context, in *ByeRequest, opts ...grpc.CallOption) (*ByeResponse, error)
 }
 
 type helloServiceClient struct {
@@ -165,9 +248,19 @@ func (c *helloServiceClient) Hello(ctx context.Context, in *HelloRequest, opts .
 	return out, nil
 }
 
+func (c *helloServiceClient) Bye(ctx context.Context, in *ByeRequest, opts ...grpc.CallOption) (*ByeResponse, error) {
+	out := new(ByeResponse)
+	err := c.cc.Invoke(ctx, "/backend.services.v1.HelloService/Bye", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // HelloServiceServer is the server API for HelloService service.
 type HelloServiceServer interface {
 	Hello(context.Context, *HelloRequest) (*HelloResponse, error)
+	Bye(context.Context, *ByeRequest) (*ByeResponse, error)
 }
 
 // UnimplementedHelloServiceServer can be embedded to have forward compatible implementations.
@@ -176,6 +269,9 @@ type UnimplementedHelloServiceServer struct {
 
 func (*UnimplementedHelloServiceServer) Hello(ctx context.Context, req *HelloRequest) (*HelloResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Hello not implemented")
+}
+func (*UnimplementedHelloServiceServer) Bye(ctx context.Context, req *ByeRequest) (*ByeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Bye not implemented")
 }
 
 func RegisterHelloServiceServer(s *grpc.Server, srv HelloServiceServer) {
@@ -200,6 +296,24 @@ func _HelloService_Hello_Handler(srv interface{}, ctx context.Context, dec func(
 	return interceptor(ctx, in, info, handler)
 }
 
+func _HelloService_Bye_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ByeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HelloServiceServer).Bye(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/backend.services.v1.HelloService/Bye",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HelloServiceServer).Bye(ctx, req.(*ByeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _HelloService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "backend.services.v1.HelloService",
 	HandlerType: (*HelloServiceServer)(nil),
@@ -207,6 +321,10 @@ var _HelloService_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Hello",
 			Handler:    _HelloService_Hello_Handler,
+		},
+		{
+			MethodName: "Bye",
+			Handler:    _HelloService_Bye_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/sample/backend-service/client/client.go
+++ b/sample/backend-service/client/client.go
@@ -30,11 +30,24 @@ func backendCheck(conn *grpc.ClientConn) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	backendHello(ctx, client)
+	backendBye(ctx, client)
+}
+
+func backendHello(ctx context.Context, client backend_service.HelloServiceClient) {
 	req := &backend_service.HelloRequest{}
 	message, err := client.Hello(ctx, req)
 	if err != nil {
 		panic(err)
 	}
-
 	log.Printf("backend.Hello() message=%+v\n", message)
+}
+
+func backendBye(ctx context.Context, client backend_service.HelloServiceClient) {
+	req := &backend_service.ByeRequest{}
+	message, err := client.Bye(ctx, req)
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("backend.Bye() message=%+v\n", message)
 }

--- a/sample/backend-service/main.go
+++ b/sample/backend-service/main.go
@@ -80,6 +80,19 @@ func (bs *backendServer) Hello(
 	}).Info("Hello()")
 
 	return &backend_services_v1.HelloResponse{
-		Message: fmt.Sprintf("%d", codes.OK),
+		Message: fmt.Sprintf("world (code=%d)", codes.OK),
+	}, nil
+}
+
+func (bs *backendServer) Bye(
+	ctx context.Context,
+	req *backend_services_v1.ByeRequest,
+) (*backend_services_v1.ByeResponse, error) {
+	log.WithFields(log.Fields{
+		"request": req,
+	}).Info("Bye()")
+
+	return &backend_services_v1.ByeResponse{
+		Message: fmt.Sprintf("bye (code=%d)", codes.OK),
 	}, nil
 }

--- a/sample/backend-service/main.go
+++ b/sample/backend-service/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net"
 	"os"
+	"time"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
@@ -79,6 +81,10 @@ func (bs *backendServer) Hello(
 		"request": req,
 	}).Info("Hello()")
 
+	// NOTE: sleep for rondom milliseconds for benchmarking
+	r := rand.Intn(100) // up to 100 msec
+	time.Sleep(time.Duration(r) * time.Millisecond)
+
 	return &backend_services_v1.HelloResponse{
 		Message: fmt.Sprintf("world (code=%d)", codes.OK),
 	}, nil
@@ -91,6 +97,10 @@ func (bs *backendServer) Bye(
 	log.WithFields(log.Fields{
 		"request": req,
 	}).Info("Bye()")
+
+	// NOTE: sleep for rondom milliseconds for benchmarking
+	r := rand.Intn(500) // up to 500 msec
+	time.Sleep(time.Duration(r) * time.Millisecond)
 
 	return &backend_services_v1.ByeResponse{
 		Message: fmt.Sprintf("bye (code=%d)", codes.OK),

--- a/sample/load-test.yml
+++ b/sample/load-test.yml
@@ -26,3 +26,7 @@ scenarios:
     - Hello:
         id: 3
         name: Chris
+    - Bye:
+        id: 4
+    - Bye:
+        id: 5

--- a/sample/load-test.yml
+++ b/sample/load-test.yml
@@ -14,18 +14,19 @@ config:
 scenarios:
   - name: test backend-service running at http://localhost:8000
     engine: grpc
-    flow:
     # list RPC names with its arguments
-    - Hello:
-        id: 1
-        name: Alice
-    - Hello:
-        id: 2
-        name: Bob
-    - Hello:
-        id: 3
-        name: Chris
-    - Bye:
-        id: 4
-    - Bye:
-        id: 5
+    flow:
+      - log: 'scenario started'
+      - Hello:
+          id: 1
+          name: Alice
+      - Hello:
+          id: 2
+          name: Bob
+      - Hello:
+          id: 3
+          name: Chris
+      - Bye:
+          id: 4
+      - Bye:
+          id: 5

--- a/sample/load-test.yml
+++ b/sample/load-test.yml
@@ -16,7 +16,8 @@ scenarios:
     engine: grpc
     # list RPC names with its arguments
     flow:
-      - log: 'scenario started'
+      # You can log any prefereed string
+      # - log: 'scenario started'
       - Hello:
           id: 1
           name: Alice

--- a/sample/load-test.yml
+++ b/sample/load-test.yml
@@ -3,7 +3,7 @@ config:
   target: 127.0.0.1:8080
   phases:
     - duration: 10 #sec
-      arrivalRate: 10
+      arrivalRate: 1
   engines:
     grpc:
       protobufDefinition:

--- a/sample/load-test.yml
+++ b/sample/load-test.yml
@@ -4,7 +4,6 @@ config:
   phases:
     - duration: 10 #sec
       arrivalRate: 10
-      pause: 15 #sec
   engines:
     grpc:
       protobufDefinition:

--- a/sample/protobuf-definitions/backend/services/v1/hello.proto
+++ b/sample/protobuf-definitions/backend/services/v1/hello.proto
@@ -3,8 +3,8 @@ syntax = "proto3";
 package backend.services.v1;
 
 service HelloService {
-    rpc Hello (HelloRequest) returns (HelloResponse) {
-    }
+    rpc Hello (HelloRequest) returns (HelloResponse);
+    rpc Bye (ByeRequest) returns (ByeResponse);
 }
 
 message HelloRequest {
@@ -13,5 +13,13 @@ message HelloRequest {
 }
 
 message HelloResponse {
+    string message = 1;
+}
+
+message ByeRequest {
+    int32 id = 1;
+}
+
+message ByeResponse {
     string message = 1;
 }


### PR DESCRIPTION
Now artillery-engine-grpc count

- responses count (total/error/success)
- response_time in milliseconds (using [hrtime](https://nodejs.org/api/process.html#process_process_hrtime_time) with high accuracy)

## Output report example

> NOTE: unrelated output are truncated

```
All virtual users finished
Summary report @ 00:11:43(+0900) 2020-02-29
  Scenarios launched:  10
  Scenarios completed: 10
  Requests completed:  50
  Scenario counts:
    test backend-service running at http://localhost:8000: 10 (100%)
  engine.grpc.response_time:
    min: 108.9
    max: 9634.7
    median: 4834.8
    p95: 9182.7
    p99: 9634.7
  engine.grpc.responses.total: 50
  engine.grpc.responses.success: 50
```