### PR TITLE
feat: support beforeRequest hook

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
+.github/
+docs/
 sample/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/artillery-engine-grpc.svg)](https://badge.fury.io/js/artillery-engine-grpc) ![Publish Node.js Package](https://github.com/kenju/artillery-engine-grpc/workflows/Publish%20Node.js%20Package/badge.svg)
 
-Load test gRPC application with [Artillery.io](https://github.com/orchestrated-io/artillery-engine-lambd)
+Load test gRPC application with [Artillery.io](https://artillery.io/)
 
 ## Documentation
 

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -2,6 +2,16 @@
 
 A development guide.
 
+## Logging
+
+We use [`debug`](https://www.npmjs.com/package/debug) package for debugging with `engine:grpc` tag.
+
+To show debug log, add `DEBUG=engine:grpc` to the environments.
+
+```
+DEBUG=engine:grpc npm run start
+```
+
 ## Publish
 
 We use [GitHub Actions](https://help.github.com/en/actions) workflow to publish packages to https://www.npmjs.com/package/artillery-engine-grpc.


### PR DESCRIPTION
this beforeRequest hook is supposed to be used along with:
https://github.com/kenju/artillery-plugin-loadbalancer

but the interface is designed to be used by another plugin as well.

## NOTE

If you are interested in an example of beforeRequest hook, please have a look at `sample/` directory of https://github.com/kenju/artillery-plugin-loadbalancer.

https://github.com/kenju/artillery-plugin-loadbalancer/tree/b947ef07d016607297da1d3181f3ac89824c2e5d/sample