### PR TITLE
feat: set grpc-ChannelOpts with `config.engines.grpc.channelOpts`

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -53,6 +53,18 @@ grpc:
     service: HelloService
 ```
 
+### `config.engines.grpc.channelOpts` (optional)
+
+You can set [grpc-ChannelOptions](https://grpc.github.io/grpc/node/grpc.Channel.html).
+
+The available options are listed at https://grpc.github.io/grpc/core/group__grpc__arg__keys.html
+
+```yaml
+grpc:
+  channelOpts:
+    grpc.client_idle_timeout_ms: 1000
+```
+
 ### `config.engines.grpc.protoLoaderConfig` (optional)
 
 artillery-engine-grpc use [@grpc/proto-loader](https://www.npmjs.com/package/@grpc/proto-loader) for loading .proto files. You can pass its configuration via `protoLoaderConfig` attributes.

--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ ArtilleryGRPCEngine.prototype.loadServiceClient = function initClient(config) {
 }
 
 ArtilleryGRPCEngine.prototype.initGRPCClient = function initClient(target) {
-  return new this.serviceClient(target, grpc.credentials.createInsecure())
+  const { channelOpts } = this.script.config.engines.grpc
+  return new this.serviceClient(target, grpc.credentials.createInsecure(), channelOpts)
 }
 
 ArtilleryGRPCEngine.prototype.createScenario = function createScenario(scenarioSpec, ee) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function ArtilleryGRPCEngine(script, ee, helpers) {
   this.helpers = helpers
 
   const { config } = this.script
-  debug(config)
+  debug('script.config=%O', config)
 
   // Hash<K, V>: K=target, V=grPC client
   this.serviceClient = this.loadServiceClient(config)
@@ -24,19 +24,25 @@ function ArtilleryGRPCEngine(script, ee, helpers) {
 }
 
 ArtilleryGRPCEngine.prototype.loadServiceClient = function initClient(config) {
-  const { engines } = config
+  const {
+    protobufDefinition,
+    protoLoaderConfig,
+  } = config.engines.grpc
+
+  debug('protobufDefinition=%O', protobufDefinition)
+  debug('protoLoaderConfig=%O', protoLoaderConfig)
 
   const {
     filepath,
     service,
     package,
-  } = engines.grpc.protobufDefinition
+  } = protobufDefinition
 
   // @return GrpcObject
   function loadPackageDefinition() {
     const packageDefinition = protoLoader.loadSync(
       filepath,
-      engines.grpc.protoLoaderConfig || {},
+      protoLoaderConfig || {},
     )
     return grpc.loadPackageDefinition(packageDefinition)
   }
@@ -49,6 +55,7 @@ ArtilleryGRPCEngine.prototype.loadServiceClient = function initClient(config) {
 
 ArtilleryGRPCEngine.prototype.initGRPCClient = function initClient(target) {
   const { channelOpts } = this.script.config.engines.grpc
+  debug('channelOpts=%O', channelOpts)
   return new this.serviceClient(target, grpc.credentials.createInsecure(), channelOpts)
 }
 

--- a/index.js
+++ b/index.js
@@ -55,8 +55,19 @@ ArtilleryGRPCEngine.prototype.loadServiceClient = function initClient(config) {
 
 ArtilleryGRPCEngine.prototype.initGRPCClient = function initClient(target) {
   const { channelOpts } = this.script.config.engines.grpc
-  debug('channelOpts=%O', channelOpts)
-  return new this.serviceClient(target, grpc.credentials.createInsecure(), channelOpts)
+  /**
+   * Filter out invalid channelOpts for gRPC client.
+   * Channel third argument must be "an object with string keys and integer or string values"
+   *
+   * @see https://github.com/kenju/artillery-engine-grpc/pull/8/files#issuecomment-594329331
+   */
+  const opts = Object.keys(channelOpts).reduce((acc, k) => {
+    if (typeof channelOpts[k] === "string" || typeof channelOpts[k] === "number") {
+      acc[k] = channelOpts[k]
+    }
+    return acc
+  }, {})
+  return new this.serviceClient(target, grpc.credentials.createInsecure(), opts)
 }
 
 ArtilleryGRPCEngine.prototype.createScenario = function createScenario(scenarioSpec, ee) {

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,0 +1,7 @@
+.PHONY: start
+start:
+	docker-compose up --build
+
+.PHONY: load
+load:
+	DEBUG=engine:grpc npm run start

--- a/sample/load-test.yml
+++ b/sample/load-test.yml
@@ -7,6 +7,12 @@ config:
   engines:
     # artillery-engine-grpc's specific configuration
     grpc:
+      # can set grpc-ChannelOptions
+      # https://grpc.github.io/grpc/node/grpc.Channel.html
+      # the available options are listed at:
+      # https://grpc.github.io/grpc/core/group__grpc__arg__keys.html
+      channelOpts:
+        grpc.client_idle_timeout_ms: 1000
       # specify .proto file basic information
       protobufDefinition:
         filepath: protobuf-definitions/backend/services/v1/hello.proto

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "13.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.6.tgz",
-      "integrity": "sha512-eyK7MWD0R1HqVTp+PtwRgFeIsemzuj4gBFSQxfPHY5iMjS7474e5wq+VFgTcdpyHeNxyKSaetYAjdMLJlKoWqA=="
+      "version": "13.7.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
+      "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
     },
     "after": {
       "version": "0.8.2",
@@ -426,9 +426,9 @@
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
     "csv-parse": {
-      "version": "4.8.6",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.6.tgz",
-      "integrity": "sha512-rSJlpgAjrB6pmlPaqiBAp3qVtQHN07VxI+ozs+knMsNvgh4bDQgENKLFYLFMvT+jn/wr/zvqsd7IVZ7Txdkr7w=="
+      "version": "4.8.8",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.8.tgz",
+      "integrity": "sha512-Kv3Ilz2GV58dOoHBXRCTF8ijxlLjl80bG3d67XPI6DNqffb3AnbPbKr/WvCUMJq5V0AZYi6sukOaOQAVpfuVbg=="
     },
     "dashdash": {
       "version": "1.14.1",


### PR DESCRIPTION
You can set [grpc-ChannelOptions](https://grpc.github.io/grpc/node/grpc.Channel.html).

The available options are listed at https://grpc.github.io/grpc/core/group__grpc__arg__keys.html

```yaml
grpc:
  channelOpts:
    grpc.client_idle_timeout_ms: 1000
```