### PR TITLE
Fix Templating Issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ ArtilleryGRPCEngine.prototype.step = function step(ops, ee, scenarioSpec) {
     const grpcMetadata = this.buildGRPCMetadata()
 
     Object.keys(ops).map((rpcName) => {
-      const args = ops[rpcName]
+      const args = this.helpers.template(ops[rpcName], context)
       /** @doc https://grpc.github.io/grpc/node/grpc.Client.html */
       client[rpcName](args, grpcMetadata, (error, response) => {
 


### PR DESCRIPTION
@kenju 
This should fix expected context application on gRPC requests - this should allow for expected context application similar to the base artillery framework
i.e. - {{ variable_here }}